### PR TITLE
Improve Efficiency for Large Files

### DIFF
--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -911,8 +911,9 @@ calPad_content = """;calPad A start Z0.20
 ;calPad SB end
 M109"""
 
+output_filename = input_filename.replace('.gcode','') #get rid of any pesky .gcode extensions; Windows 11 prefers to save the filename as .gx.gcode no matter what we do.
 
-our_file = open(sys.argv[1], 'rb+')
+our_file = open(output_filename, 'wb+') #since the output filename may be different (see above), use WRITE only.
 for binary_data in header_hex:
     our_file.write(binary_data)
     

--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -80,50 +80,54 @@ file_data = "\n"
 image_extract_status = 0 #1 means we are extracting; 2 means we are done extracting
 
 input_filename = sys.argv[1]
-input_file_size = os.path.getsize(input_filename)
 
 #for print statements
 bytes_read = 0
 percent = 0
 
 #for debugging information, in terms of which line various items are on
-totline = 0
 numline = 0
 
 #this variable to is to ensure it still work for single extruder prints
 print_have_started = 0
-#inplace=True for in-place editing .... but no print statements
-for line in fileinput.input(files=(input_filename),inplace=True):
-    #print statements inside a fileinput.input(inplace=True) work a little differently....   hence the sending of prints to stderr
-    #https://stackoverflow.com/questions/61713742/how-to-print-on-the-console-when-using-inplace-true
-    
-    totline += 1
-    numline += 1
+
+
+#read once, for sole purpose of getting everything into memory
+
+file = open(input_filename, "r")
+file_data_lines = file.readlines()
+file_data = "".join(line for line in file_data_lines)  #join the whole thing together as a string; I will need this for later
+file.close()
+
+input_file_size = len(file_data_lines) #length of file, in terms of the number of lines.  Don't need to count it out byte-by-byte here...
+
+#last_line = 0 #used for deugging purposes; uncomment all of the last_line to learn how often the regex's are being called and where they're located.
+
+#go through the data forwards; loooking ONLY for the stuff that I know is usually at the front.
+for linenumber,line in enumerate(file_data_lines):
     
     #calculate percent completion and print it to the screen; for the piece of mind of the user
-    bytes_read += len(line)
-    new_percent = int(bytes_read/input_file_size*100)
-    if new_percent > percent:
+    if linenumber%10000 == 0:
         #https://stackoverflow.com/questions/3002085/how-to-print-out-status-bar-and-percentage
         #sys.stdout or sys.stderr allows the last print to be clread with \r
+
+        new_percent = int( linenumber/input_file_size*50)
         sys.stderr.write('\r') #clear last percent print
         sys.stderr.write(str(new_percent)+"%")
+        #sys.stderr.write(str(new_percent)+"%" + " Regex Status: " + str(setting_print_time[0]) + " " + str(setting_filament_usage[0]) + " " + str(setting_temps[0]) + " " + str(setting_layer_height[0]) + " " + str(setting_shells[0]) + " " + str(setting_speed[0]) + " " + str(setting_bed_temp[0]) + "\n")
         sys.stderr.flush()
-
-        percent = new_percent
     
-    #print(line, end="") #for now we keep all lines
-    file_data += line #store in memory, since we already have to get everything in memory
-    if image_extract_status == 0:
-        if thumbnail_start.match(line):
-            sys.stderr.write("Thumbnail Start Match!  Lines:"+str(numline)+"\n")
-            numline = 0
-            image_extract_status = 1
-            continue # got o next line
+
+    if image_extract_status == 0 and thumbnail_start.match(line):
+        #sys.stderr.write("\n"+"Thumbnail Start Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+        image_extract_status = 1
+        continue # got to next line
     if image_extract_status == 1:
+        #i am currently in the image
         if thumbnail_end.match(line):
-            sys.stderr.write("Thumbnail End Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+            #sys.stderr.write("\n"+"Thumbnail End Match!  Lines:"+str(linenumber - last_line)+"\n")
+            #last_line = linenumber
             image_extract_status = 2
             thumbnail_image = Image.open(BytesIO(base64.decodebytes(thumbnail_b64_content.encode('ascii')))).convert("RGB") #load as image and ensure it is RGB (1 byte per pixel)
             thumbnail_b64_content = "" # clear to save memory
@@ -131,18 +135,18 @@ for line in fileinput.input(files=(input_filename),inplace=True):
             thumbnail_image.save(thumbnail_bytes, format="BMP")
             thumbnail = thumbnail_bytes.getvalue()
             
-            continue #go to nect line
+            continue #go to next line
         else:
             m = thumbnail_content_re.match(line)
             thumbnail_b64_content += m.group(1)
     else:
-        #for each condition; check if it's not been matched yet.  If it hasn't been matched yet; then do the regex check
+        #not in the image at all
     
         #extruder match is special - there may be more than one extruder match.  Therefore, don't check the previous state; we realy do need to ingest all the data.
         if extruder_match[1].match(line): # this should match early in the file
             extruder_match[0] = True
-            sys.stderr.write("Extruder Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+            #sys.stderr.write("\n"+"Extruder Match!  Lines:"+str(linenumber - last_line)+"\n")
+            #last_line = linenumber
 
             if extruder_match[1].match(line).group(1) == "1":
                 extr_left_active = True
@@ -153,10 +157,12 @@ for line in fileinput.input(files=(input_filename),inplace=True):
                 if extr_left_active:
                     extr_both_active = True
             continue
-        if not extruder_mode_match[0] and extruder_mode_match[1].match(line): # this should match early in the file
+        if not extruder_mode_match[0] and extruder_mode_match[1].match(line): # this should match early in the file.  It should also only match once.
+            #for each condition; check if it's not been matched yet.  If it hasn't been matched yet; then do the regex check
+            
             extruder_mode_match[0] = True
-            sys.stderr.write("Extruder Mode Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+            #sys.stderr.write("\n"+"Extruder Mode Match!  Lines:"+str(linenumber - last_line)+"\n")
+            #last_line = linenumber
 
             use_calpads = True
             if extruder_mode_match[1].match(line).group(1) == "1": # mirror
@@ -164,82 +170,118 @@ for line in fileinput.input(files=(input_filename),inplace=True):
             else: # 2 = ditto
                 extruder_mode = 19
             continue
-        if not setting_print_time[0] and setting_print_time[1].match(line):
-            setting_print_time[0] = True
-            sys.stderr.write("Setting Print Time Match!  Lines:"+str(numline)+"\n")
-            numline = 0
 
-            time = setting_print_time[1].match(line).group(1).split() # this match in nnh nnm nns
-            seconds = 0
-            for part in time:
-                if matching_hours.match(part):
-                    hours = matching_hours.match(part).group(1)
-                    seconds += int(hours) * 60 * 60
-                if matching_minutes.match(part):
-                    minutes = matching_minutes.match(part).group(1)
-                    seconds += int(minutes) * 60
-                if matching_seconds.match(part):
-                    seconds += int(matching_seconds.match(part).group(1))
-            print_time_in_seconds = seconds
-            continue
-        if not setting_filament_usage[0] and setting_filament_usage[1].match(line):
-            setting_filament_usage[0] = True
-            sys.stderr.write("Setting Filament Match!  Lines:"+str(numline)+"\n")
-            numline = 0
 
-            string = setting_filament_usage[1].match(line).group(1).split(", ") # this match in nnh nnm nns
-            for part in string:
-                if not extr_both_active and extr_left_active:
-                    filament_usage_in_mm_left = int(float(part)) # should be the only part
-                elif filament_usage_in_mm_right != 0:
-                    filament_usage_in_mm_left = int(float(part)) # should be on second loop now
-                else:
-                    filament_usage_in_mm_right = int(float(part)) # might be only part or first loop
-            continue
-        if not setting_temps[0] and setting_temps[1].match(line):
-            setting_temps[0] = True
-            sys.stderr.write("Setter Temps Match!  Lines:"+str(numline)+"\n")
-            numline = 0
 
-            string = setting_temps[1].match(line).group(1).split(",") # this match in nnh nnm nns
-            for part in string:
-                if not extr_both_active and extr_left_active:
-                    left_extruder_temp = int(part) # should be the only part
-                elif right_extruder_temp != 0:
-                    left_extruder_temp = int(part) # should be on second loop now
-                else:
-                    right_extruder_temp = int(part) # might be only part or first loop
-            continue
-        if not setting_layer_height[0] and setting_layer_height[1].match(line):
-            setting_layer_height[0] = True
-            sys.stderr.write("Setting Layer Height Match!  Lines:"+str(numline)+"\n")
-            numline = 0
 
-            layer_height_microns = int(float(setting_layer_height[1].match(line).group(1)) * 1000)
-            continue
-        if not setting_shells[0] and setting_shells[1].match(line):
-            setting_shells[0] = True
-            sys.stderr.write("Setting Shells Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+#print("Going through list in reverse!")
 
-            number_perimeter_shells = int(setting_shells[1].match(line).group(1))
-            continue
-        if not setting_speed[0] and setting_speed[1].match(line):
-            setting_speed[0] = True
-            sys.stderr.write("Setting Speed Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+file_data_lines.reverse() 
 
-            print_speed = int(setting_speed[1].match(line).group(1))
-            continue
-        if not setting_bed_temp[0] and setting_bed_temp[1].match(line):
-            setting_bed_temp[0] = True
-            sys.stderr.write("Setting Bed Match!  Lines:"+str(numline)+"\n")
-            numline = 0
+#last_line = 0
 
-            platform_temp = int(setting_bed_temp[1].match(line).group(1))
-            continue
+#go through the data backwards; looking for the stuff that tends to be at the end of the header
+for linenumber,line in enumerate(file_data_lines):
+
+    #calculate percent completion and print it to the screen; for the piece of mind of the user
+    if linenumber%10000 == 0:
+        new_percent = int(50 + (linenumber/input_file_size*50))
+        sys.stderr.write('\r') #clear last percent print
+        sys.stderr.write(str(new_percent)+"%")
+        #sys.stderr.write(str(new_percent)+"%" + " Regex Status: " + str(setting_print_time[0]) + " " + str(setting_filament_usage[0]) + " " + str(setting_temps[0]) + " " + str(setting_layer_height[0]) + " " + str(setting_shells[0]) + " " + str(setting_speed[0]) + " " + str(setting_bed_temp[0]) + "\n")
+        sys.stderr.flush()
+    
+    
+    #short-circuit iteration if we're all done.
+    if all([setting_print_time[0] , setting_filament_usage[0] , setting_temps[0] , setting_layer_height[0] , setting_shells[0] , setting_speed[0] , setting_bed_temp[0] ]):
+        sys.stderr.write('\r') #clear last percent print
+        sys.stderr.write("100%")
+        sys.stderr.flush()  
+        break
+
+
+
+    if not setting_print_time[0] and setting_print_time[1].match(line):
+        setting_print_time[0] = True
+        #sys.stderr.write("\n"+"Setting Print Time Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        time = setting_print_time[1].match(line).group(1).split() # this match in nnh nnm nns
+        seconds = 0
+        for part in time:
+            if matching_hours.match(part):
+                hours = matching_hours.match(part).group(1)
+                seconds += int(hours) * 60 * 60
+            if matching_minutes.match(part):
+                minutes = matching_minutes.match(part).group(1)
+                seconds += int(minutes) * 60
+            if matching_seconds.match(part):
+                seconds += int(matching_seconds.match(part).group(1))
+        print_time_in_seconds = seconds
+        continue
+    if not setting_filament_usage[0] and setting_filament_usage[1].match(line):
+        setting_filament_usage[0] = True
+        #sys.stderr.write("\n"+"Setting Filament Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        string = setting_filament_usage[1].match(line).group(1).split(", ") # this match in nnh nnm nns
+        for part in string:
+            if not extr_both_active and extr_left_active:
+                filament_usage_in_mm_left = int(float(part)) # should be the only part
+            elif filament_usage_in_mm_right != 0:
+                filament_usage_in_mm_left = int(float(part)) # should be on second loop now
+            else:
+                filament_usage_in_mm_right = int(float(part)) # might be only part or first loop
+        continue
+    if not setting_temps[0] and setting_temps[1].match(line):
+        setting_temps[0] = True
+        #sys.stderr.write("\n"+"Setter Temps Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        string = setting_temps[1].match(line).group(1).split(",") # this match in nnh nnm nns
+        for part in string:
+            if not extr_both_active and extr_left_active:
+                left_extruder_temp = int(part) # should be the only part
+            elif right_extruder_temp != 0:
+                left_extruder_temp = int(part) # should be on second loop now
+            else:
+                right_extruder_temp = int(part) # might be only part or first loop
+        continue
+    if not setting_layer_height[0] and setting_layer_height[1].match(line):
+        setting_layer_height[0] = True
+        #sys.stderr.write("\n"+"Setting Layer Height Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        layer_height_microns = int(float(setting_layer_height[1].match(line).group(1)) * 1000)
+        continue
+    if not setting_shells[0] and setting_shells[1].match(line):
+        setting_shells[0] = True
+        #sys.stderr.write("\n"+"Setting Shells Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        number_perimeter_shells = int(setting_shells[1].match(line).group(1))
+        continue
+    if not setting_speed[0] and setting_speed[1].match(line):
+        setting_speed[0] = True
+        #sys.stderr.write("\n"+"Setting Speed Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        print_speed = int(setting_speed[1].match(line).group(1))
+        continue
+    if not setting_bed_temp[0] and setting_bed_temp[1].match(line):
+        setting_bed_temp[0] = True
+        #sys.stderr.write("\n"+"Setting Bed Match!  Lines:"+str(linenumber - last_line)+"\n")
+        #last_line = linenumber
+
+        platform_temp = int(setting_bed_temp[1].match(line).group(1))
+        continue
+
+    
+
+
+
 print() #so the next line comes out cleanly    
-fileinput.close() # ensure it is closed, so that we can read to it in binary mode
+#fileinput.close() # ensure it is closed, so that we can read to it in binary mode
 # since we store the data in memory, and did not write back, file is empty, easy to prepend header
 
 #lets now start to process our additional_data
@@ -758,6 +800,7 @@ calPad_content = """;calPad A start Z0.20
 ;:G1 X-11.01 Y-14.60 E6.8712
 ;:G1 X-10.32 Y-14.73 E6.8967
 ;:G1 X-16.40 Y-8.65 E7.2084
+
 ;:G1 X-16.40 Y-8.09 E7.2287
 ;:G1 X-9.69 Y-14.80 E7.5727
 ;:G1 X-9.12 Y-14.80 E7.5934
@@ -968,7 +1011,7 @@ calPad_content = """;calPad A start Z0.20
 M109"""
 
 
-our_file = open(input_filename, 'rb+') #since the output filename may be different (see above), use WRITE only.
+our_file = open(input_filename, 'wb') #since the output filename may be different (see above), use WRITE only.
 for binary_data in header_hex:
     our_file.write(binary_data)
     
@@ -976,3 +1019,4 @@ if use_calpads: #only required for ditto and mirror
     file_data = file_data.replace("M109", calPad_content, 1)
 
 our_file.write(file_data.encode('utf-8')) # add the actual gcode for the printer
+

--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -1014,6 +1014,7 @@ M109"""
 our_file = open(input_filename, 'wb') #since the output filename may be different (see above), use WRITE only.
 for binary_data in header_hex:
     our_file.write(binary_data)
+our_file.write("\n".encode('utf-8')) #force it onto a newline
     
 if use_calpads: #only required for ditto and mirror
     file_data = file_data.replace("M109", calPad_content, 1)

--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -911,9 +911,8 @@ calPad_content = """;calPad A start Z0.20
 ;calPad SB end
 M109"""
 
-output_filename = input_filename.replace('.gcode','') #get rid of any pesky .gcode extensions; Windows 11 prefers to save the filename as .gx.gcode no matter what we do.
 
-our_file = open(output_filename, 'wb+') #since the output filename may be different (see above), use WRITE only.
+our_file = open(input_filename, 'rb+') #since the output filename may be different (see above), use WRITE only.
 for binary_data in header_hex:
     our_file.write(binary_data)
     
@@ -921,3 +920,8 @@ if use_calpads: #only required for ditto and mirror
     file_data = file_data.replace("M109", calPad_content, 1)
 
 our_file.write(file_data.encode('utf-8')) # add the actual gcode for the printer
+
+
+output_filename = input_filename.replace('.gcode','') #get rid of any pesky .gcode extensions; Windows 11 prefers to save the filename as .gx.gcode no matter what we do.
+if output_filename != input_filename:
+    os.rename(input_filename,output_filename)

--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -920,7 +920,7 @@ if use_calpads: #only required for ditto and mirror
     file_data = file_data.replace("M109", calPad_content, 1)
 
 our_file.write(file_data.encode('utf-8')) # add the actual gcode for the printer
-
+our_file.close()
 
 output_filename = input_filename.replace('.gcode','') #get rid of any pesky .gcode extensions; Windows 11 prefers to save the filename as .gx.gcode no matter what we do.
 if output_filename != input_filename:

--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -920,8 +920,3 @@ if use_calpads: #only required for ditto and mirror
     file_data = file_data.replace("M109", calPad_content, 1)
 
 our_file.write(file_data.encode('utf-8')) # add the actual gcode for the printer
-
-
-output_filename = input_filename.replace('.gcode','') #get rid of any pesky .gcode extensions; Windows 11 prefers to save the filename as .gx.gcode no matter what we do.
-if output_filename != input_filename:
-    os.rename(input_filename,output_filename)


### PR DESCRIPTION
Hello!  I have found your preprocessing script very useful for my Flashforge Creator pro (I have 3 of them).

I typically print **very** large files on my CreatorPro2; typically, they take 1-2 days to pint.

Recently, I got a new computer, and after setting up PrusaSlicer and your extension; the exporting process would never finish.

The code was taking hours when it used to take ~2 minutes.  I eventually tracked this problem down to a combination of Python versions (3.11 vs 3.10) and inefficient calling of regex.

I would like to submit a pull request with the following changes:

-  Introduce a progress % shown on the screen.
- Improve the efficiency of the code by more judiciously using regex.  Specifically:
- Remember when a regex has found a match.  If a regex has found a match; do not keep running that regex for subsequent lines. 
- Leverage the fact that most of the lines to be matched are typically at the very beginning or very ending of the file to more judiciously search for the right data.  More specifically, some of the regexes search for data that is typically at the beginning of the file.  Loop through the gcode file _forwards_, looking for only data at the beginning of the file.  Then, loop through the gcode file _backwards_, looking only for data that is typically at the end of the file.

These changes put together make a substantial difference in runtime.   For testing, I ran this code on a large gcode file "PanTiltBotCabling.gx.gcode", under various parameters.  This file is rather large (53MB).

The original code, on a chromebook running python3.8, took 34 seconds to run and called regex 21.2 Million times:



```
python3.8 -m cProfile -s tottime ~/FlashForge-CreatorPro2-PS-Profile/post-processor/ff-creator-post-processor.py PanTiltBotCabling.gx.gcode
         26010583 function calls (26009787 primitive calls) in 33.912 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1   15.234   15.234   33.912   33.912 ff-creator-post-processor.py:14(<module>)
 21230873   13.087    0.000   13.087    0.000 {method 'match' of 're.Pattern' objects}
  2359063    3.448    0.000    5.121    0.000 fileinput.py:246(__next__)
  2359063    1.599    0.000    1.658    0.000 {method 'readline' of '_io.TextIOWrapper' objects}
```

The original code, on a chromebook running python 3.11, timed out after **over two hours** of runtime.

The new code, on a chromebook running python 3.8, took 10.5 seconds and (only) 4.7 Million calls to regex:

```
python3.8 -m cProfile -s tottime ~/FlashForge-CreatorPro2-PS-Profile/post-processor/ff-creator-post-processor.py PanTiltBotCabling.gx.gcode
100%
         7134459 function calls (7133663 primitive calls) in 10.492 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    4.433    4.433   10.492   10.492 ff-creator-post-processor.py:14(<module>)
  4719545    2.625    0.000    2.625    0.000 {method 'match' of 're.Pattern' objects}
     1029    0.862    0.001    1.410    0.001 {method 'join' of 'str' objects}
        1    0.848    0.848    0.898    0.898 {method 'readlines' of '_io._IOBase' objects}
```

The new code, on a chromebook running python 3.8, took 16 seconds and an identical number of calls to regex:

```
python3.11 -m cProfile -s tottime ~/FlashForge-CreatorPro2-PS-Profile/post-processor/ff-creator-post-processor.py PanTiltBotCabling.gx.gcode
100%
         7140131 function calls (7138972 primitive calls) in 15.957 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    8.486    8.486   15.957   15.957 ff-creator-post-processor.py:1(<module>)
  4719545    3.671    0.000    3.671    0.000 {method 'match' of 're.Pattern' objects}
      954    0.941    0.001    1.682    0.002 {method 'join' of 'str' objects}
        1    0.877    0.877    0.938    0.938 {method 'readlines' of '_io._IOBase' objects}
```

The root cause of this problem is inefficiency (many millions of calls to regex) and [python 3.11 making many, many changes to regex](https://docs.python.org/3/whatsnew/changelog.html#changelog), one of which presumably slowed this specific regex down greatly.

I have tested that this new code produces 100% identical results to the original code; at least for the prints I run.

Please consider this change!  I hope this helps people out! 