### PR TITLE
automatically install Pillow dependancy for currently running python instance (non flatpak only)

### DIFF
--- a/post-processor/ff-creator-post-processor.py
+++ b/post-processor/ff-creator-post-processor.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3-64
+#! /usr/bin/python
 # ff-creator-post-processor.py
 
 # LICENSE & COPYRIGHT
@@ -10,6 +10,17 @@
 # The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import importlib
+try:
+    importlib.import_module("PIL.Image")
+except ImportError:
+    import pip
+    pip.main(['install', "Pillow"])
+    globals()["PIL"] = importlib.import_module("PIL")
+finally:
+    from PIL import Image
+
 
 import fileinput
 import re


### PR DESCRIPTION
I had some trouble with git... may want to squash the 6 commits with "squash and merge" option in github. but anyway:

added a simple snippet to automatically install Pillow for whatever version of python and whatever python environment is currently running. this is useful as most people have multiple python installs on their system. also this simplifies the profile installation. 

It doesn't work for flatpak (linux) as the flatpak version of python does not come with the ability to install modules (pip). this can be remedied by manually adding pip to flatpak's python instance, but its kinda hacky:
tested on Fedora39 and PrusaSlicer-2.7.1+flathub.org
```
sudo dnf install -y python3.11
/usr/bin/python3.11 -m pip install --upgrade --user pip
sudo cp -R /home/$USER/.local/lib/python3.11/site-packages/pip /home/yer/.var/app/com.prusa3d.PrusaSlicer/data/python/lib/python3.11/site-packages/
```
and then running the flash print profile 
I'll work on a better solution and if you accept this pull request I will update the readme to reflect my changes. thanks.
