### PR TITLE
Remove duplicate repo_id key from FlashForge.ini

### DIFF
--- a/vendor/FlashForge.ini
+++ b/vendor/FlashForge.ini
@@ -1,7 +1,6 @@
  # Print profiles for the FlashForge Creator Pro 2 IDEX printer.
 
 [vendor]
-repo_id = non-prusa-fff
 # Vendor name will be shown by the Config Wizard.
 name = FlashForge
 # Configuration version of this file. Config file will only be installed, if the config_version differs.


### PR DESCRIPTION
Thanks for creating this repo!  
Tested on PS v2.9.0 today, it was complaining about duplicate keys in FlashForge.ini line 12
The line `repo_id = non-prusa-fff` was duplicated in the `[vendor]` section.
This PR removes one of them :+1: 
